### PR TITLE
Addition of a embed url

### DIFF
--- a/Nextras/YoutubeApi/Reader.php
+++ b/Nextras/YoutubeApi/Reader.php
@@ -104,6 +104,7 @@ class Reader extends Nette\Object
 		$video->title = $snippet->title;
 		$video->description = $snippet->description;
 		$video->url = 'http://www.youtube.com/watch?v=' . $videoId;
+		$video->embed = 'https://www.youtube.com/embed/' . $videoId;
 
 		$interval = new DateInterval($details->duration);
 		$video->duration = $interval->days * 86400 + $interval->h * 3600 + $interval->i * 60 + $interval->s;

--- a/Nextras/YoutubeApi/Video.php
+++ b/Nextras/YoutubeApi/Video.php
@@ -28,4 +28,7 @@ class Video extends Nette\Object
 
 	/** @var array */
 	public $thumbs;
+	
+	/** @var string */
+	public $embed;
 }

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ echo $video->title;
 echo $video->duration; // in sec
 echo $video->description;
 echo $video->url;
+echo $video->embed;
 foreach ($video->thumbs as $thumb) {
     echo $video->url; 
 }


### PR DESCRIPTION
With this fork it´s possible for the user of nextras/youtube-api to get the url used to embed the video this is a simple addition but i feel like it is a useful addition to the users.

This is the first time i am doing a pull request so feel free to mention any mistake i am doing with this pull request.