### PR TITLE
Remove deprecated class Nette\Object

### DIFF
--- a/Nextras/YoutubeApi/Reader.php
+++ b/Nextras/YoutubeApi/Reader.php
@@ -14,8 +14,10 @@ use GuzzleHttp\Client;
 use Nette;
 
 
-class Reader extends Nette\Object
+class Reader
 {
+	use Nette\SmartObject;
+
 	/** @var string */
 	const FETCH_URL = 'https://www.googleapis.com/youtube/v3/videos?key=%s&part=snippet,contentDetails&id=%s';
 

--- a/Nextras/YoutubeApi/Video.php
+++ b/Nextras/YoutubeApi/Video.php
@@ -12,8 +12,10 @@ use Nette;
 
 
 
-class Video extends Nette\Object
+class Video
 {
+	use Nette\SmartObject;
+
 	/** @var string */
 	public $title;
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	],
 	"require": {
 		"php": ">=5.6",
-		"nette/utils": "~2.2",
+		"nette/utils": "~2.4",
 		"nette/http": "~2.2",
 		"composer/ca-bundle": "~1.0",
 		"guzzlehttp/guzzle": "~6.2"


### PR DESCRIPTION
This just remove `Nette\Object` and use `Nette\SmartObject` instead.